### PR TITLE
Fixes an error in the shar for patch01

### DIFF
--- a/dist/patch01
+++ b/dist/patch01
@@ -68,7 +68,7 @@ cat > jobs.pch <<\!
         }
         INTOFF;
         jp->state = 0;
-EOF
+!
 echo extracting README.CONFIG
 cat > README.CONFIG <<\!
 The config shell procedure is used to configure ash to reflect the


### PR DESCRIPTION
### Description

The original shar (and the original [post](https://groups.google.com/g/comp.sources.unix/c/pEhAvMEn0lg/m/0Ebs8uR8F4IJ) on USENET) used EOF for the end of the jobs.pch patch HEREDOC. 
But that is *not* the label that was used for opening the HEREDOC: 
```
cat > jobs.pch <<\!
```
Replaced `EOF` with `!`

### Extracting without my change:

```
extracting jobs.pch
./patch01: line 80: README.CONFIG: No such file or directory
./patch01: line 80: test: -ne: unary operator expected
extracting config
Archive unpacked
```

### With my change:

```
extracting jobs.pch
extracting README.CONFIG
extracting config
Archive unpacked
```
***
<img alt="enjoy this fancy (autumn ready) cat" src="https://www.womansworld.com/wp-content/uploads/2019/01/cats-in-hats-1.jpg" width="474" height="355">